### PR TITLE
ENG-10517: Add deprecation note to the mysql_multiplexed_port variable

### DIFF
--- a/variables_sidecar.tf
+++ b/variables_sidecar.tf
@@ -83,7 +83,10 @@ EOF
 }
 
 variable "mysql_multiplexed_port" {
-  description = "Port that will be used by the sidecar to multiplex connections to MySQL"
+  description = <<EOF
+(Deprecated) Port that will be used by the sidecar to multiplex connections to MySQL.
+This variable is deprecated for sidecars v4.0.0 and later.
+EOF
   type        = number
   default     = 0
 }


### PR DESCRIPTION
## Description

**ENG-10517**: Add deprecation note to the `mysql_multiplexed_port` variable

mysql_multiplexed_port is deprecated for sidecars v4.0.0 and later, as the multiplexing state is now
detached from any template configuration.

This variable will eventually be removed from the terraform module in a future release.

Current sidecars should keep working as is.