### PR TITLE
ENG-10518: Add deprecation note to the mongodb low/high alloc ports variables

### DIFF
--- a/variables_sidecar.tf
+++ b/variables_sidecar.tf
@@ -60,11 +60,13 @@ variable "metrics_integration" {
 
 variable "mongodb_port_alloc_range_low" {
   description = <<EOF
-Initial value for MongoDB port allocation range. This is mandatory for MongoDB
+(Deprecated) Initial value for MongoDB port allocation range. This is mandatory for MongoDB
 use case and the consecutive ports in the
 range `mongodb_port_alloc_range_low:mongodb_port_alloc_range_high` will be used
 for mongodb cluster monitoring. All the ports in this range must be listed in
 `sidecar_ports`.
+
+This variable is deprecated for sidecars v3.0.0 and later.
 EOF
   type        = number
   default     = 27017
@@ -72,11 +74,13 @@ EOF
 
 variable "mongodb_port_alloc_range_high" {
   description = <<EOF
-Final value for MongoDB port allocation range. This is mandatory for MongoDB
+(Deprecated) Final value for MongoDB port allocation range. This is mandatory for MongoDB
 use case and the consecutive ports in the
 range `mongodb_port_alloc_range_low:mongodb_port_alloc_range_high` will be used
 for mongodb cluster monitoring. All the ports in this range must be listed in
 `sidecar_ports`.
+
+This variable is deprecated for sidecars v3.0.0 and later.
 EOF
   type        = number
   default     = 27019


### PR DESCRIPTION
## Description

ENG-10518: Add deprecation note to the mongodb low/high alloc ports variables

    mongodb_port_alloc_range_low and mongodb_port_alloc_range_high are deprecated
    for sidecars v3.0.0 and later and will eventually be removed from the terraform module.

    Current sidecars should keep working as is.