### PR TITLE
ENG-11888: Add external parameter to name cloudwatch log groups

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,17 +9,15 @@ provider "aws" {
 
 module "cyral_sidecar" {
     source  = "cyralinc/sidecar-ec2/aws"  
-    version = "~> 3.0" # terraform module version
+    version = "~> 4.0" # terraform module version
 
     sidecar_version = ""
     sidecar_id      = ""
 
     control_plane = ""
+
     # Considering MongoDB ports are from the range 27017 to 27021
     sidecar_ports = [443, 3306, 5432, 27017, 27018, 27019, 27020, 27021]
-    # If `repositories_supported` is ommitted, all repositories will be supported,
-    # though you have to open the desired ports using `sidecar_ports`.
-    repositories_supported = ["snowflake", "postgresql", "mysql", "mongodb"]
 
     vpc_id  = ""
     subnets = [""]
@@ -119,6 +117,7 @@ No modules.
 | <a name="input_associate_public_ip_address"></a> [associate\_public\_ip\_address](#input\_associate\_public\_ip\_address) | Associates a public IP to sidecar EC2 instances | `bool` | `false` | no |
 | <a name="input_client_id"></a> [client\_id](#input\_client\_id) | The client id assigned to the sidecar | `string` | n/a | yes |
 | <a name="input_client_secret"></a> [client\_secret](#input\_client\_secret) | The client secret assigned to the sidecar | `string` | n/a | yes |
+| <a name="input_cloudwatch_log_group_name"></a> [cloudwatch\_log\_group\_name](#input\_cloudwatch\_log\_group\_name) | (Optional) Cloudwatch log group name. | `string` | `""` | no |
 | <a name="input_cloudwatch_logs_retention"></a> [cloudwatch\_logs\_retention](#input\_cloudwatch\_logs\_retention) | Cloudwatch logs retention in days | `number` | `14` | no |
 | <a name="input_container_registry"></a> [container\_registry](#input\_container\_registry) | Address of the container registry where Cyral images are stored | `string` | n/a | yes |
 | <a name="input_container_registry_key"></a> [container\_registry\_key](#input\_container\_registry\_key) | Key provided by Cyral for authenticating on Cyral's container registry | `string` | `""` | no |

--- a/cloudwatch_resources.tf
+++ b/cloudwatch_resources.tf
@@ -1,4 +1,4 @@
 resource "aws_cloudwatch_log_group" "cyral-sidecar-lg" {
-  name              = local.name_prefix
+  name              = local.cloudwatch_log_group_name
   retention_in_days = var.cloudwatch_logs_retention
 }

--- a/ec2_locals.tf
+++ b/ec2_locals.tf
@@ -12,9 +12,10 @@ locals {
     ) : (
     length(aws_route53_record.cyral-sidecar-dns-record) == 1 ? aws_route53_record.cyral-sidecar-dns-record[0].fqdn : aws_lb.cyral-lb.dns_name
   )
-  protocol    = var.external_tls_type == "no-tls" ? "http" : "https"
-  curl        = var.external_tls_type == "tls-skip-verify" ? "curl -k" : "curl"
-  name_prefix = var.name_prefix == "" ? "cyral-${substr(lower(var.sidecar_id), -6, -1)}" : var.name_prefix
+  protocol                  = var.external_tls_type == "no-tls" ? "http" : "https"
+  curl                      = var.external_tls_type == "tls-skip-verify" ? "curl -k" : "curl"
+  name_prefix               = var.name_prefix == "" ? "cyral-${substr(lower(var.sidecar_id), -6, -1)}" : var.name_prefix
+  cloudwatch_log_group_name = var.cloudwatch_log_group_name == "" ? local.name_prefix : var.cloudwatch_log_group_name
 
   templatevars = {
     sidecar_id                            = var.sidecar_id
@@ -40,6 +41,7 @@ locals {
     curl                                  = local.curl
     sidecar_version                       = var.sidecar_version
     repositories_supported                = join(",", var.repositories_supported)
+    cloudwatch_log_group_name             = local.cloudwatch_log_group_name
     sidecar_tls_certificate_secret_arn = (
       var.sidecar_tls_certificate_secret_arn != "" ?
       var.sidecar_tls_certificate_secret_arn :

--- a/variables_sidecar.tf
+++ b/variables_sidecar.tf
@@ -157,3 +157,9 @@ variable "sidecar_custom_host_role" {
   type        = string
   default     = ""
 }
+
+variable "cloudwatch_log_group_name" {
+  description = "(Optional) Cloudwatch log group name."
+  type        = string
+  default     = ""
+}


### PR DESCRIPTION
By creating this external variable, users will be able to set the log group name, and the circular dependency that may happen will cease to exist.

This was the problem before:

```
resource "cyral_sidecar" "sidecar" {
    name = "my-sidecar"
    deployment_method = "terraform"
    log_integration_id = cyral_integration_logging.cloudwatch.id
}

resource "cyral_integration_logging" "cloudwatch" {
  name = "my-cloudwatch"
  cloud_watch {
    region = "us-east-1"
    group  = module.cyral_sidecar.aws_cloudwatch_log_group_name
    stream = "cyral-sidecar"
  }
}

module "cyral_sidecar" {
    source  = "cyralinc/sidecar-ec2/aws"  
    version = "~> 4.0"

    sidecar_id      = cyral_sidecar.sidecar.id
    ...
}
```

And now we can do this:

```
locals {
    cloudwatch_log_group_name = "my-log-group"
}

resource "cyral_sidecar" "sidecar" {
    name = "my-sidecar"
    deployment_method = "terraform"
    log_integration_id = cyral_integration_logging. cloudwatch.id
}

resource "cyral_integration_logging" "cloudwatch" {
  name = "my-cloudwatch"
  cloud_watch {
    region = "us-east-1"
    group  = local.cloudwatch_log_group_name
    stream = "cyral-sidecar"
  }
}

module "cyral_sidecar" {
    source  = "cyralinc/sidecar-ec2/aws"  
    version = "~> 4.0"

    sidecar_version = ""
    sidecar_id      = cyral_sidecar.sidecar.id

    cloudwatch_log_group_name = local.cloudwatch_log_group_name
    ...
}
```