### PR TITLE
ENG-11901: Enable docker service for instance restarts

### DIFF
--- a/files/cloud-init-functions.sh.tmpl
+++ b/files/cloud-init-functions.sh.tmpl
@@ -21,6 +21,7 @@ DAEMON_MAXFILES=65535
 OPTIONS="--default-ulimit nofile=65535:65535"
 DAEMON_PIDFILE_TIMEOUT=10
 EOF
+    sudo systemctl enable docker
     sudo systemctl restart docker
 }
 


### PR DESCRIPTION
# Description
Enables the docker service instead of just starting it so that on instance restarts
the docker services also restart.

## Testing
Created an instance and restarted it using the UI and `systemctl reboot`, in both cases
the containers started without interference.
