### PR TITLE
ENG-12176: Add parameter to disable TLS certificate verification to sidecar templates

### DIFF
--- a/README.md
+++ b/README.md
@@ -169,6 +169,7 @@ No modules.
 | <a name="input_ssh_inbound_cidr"></a> [ssh\_inbound\_cidr](#input\_ssh\_inbound\_cidr) | Allowed CIDR block for SSH access to the sidecar. Can't be combined with 'ssh\_inbound\_security\_group'. | `list(string)` | n/a | yes |
 | <a name="input_ssh_inbound_security_group"></a> [ssh\_inbound\_security\_group](#input\_ssh\_inbound\_security\_group) | Pre-existing security group IDs allowed to ssh into the EC2 host. Can't be combined with 'ssh\_inbound\_cidr'. | `list(string)` | `[]` | no |
 | <a name="input_subnets"></a> [subnets](#input\_subnets) | Subnets to add sidecar to (list of string) | `list(string)` | n/a | yes |
+| <a name="input_tls_skip_verify"></a> [tls\_skip\_verify](#input\_tls\_skip\_verify) | (Optional) Skip TLS verification for HTTPS communication with the control plane and during sidecar initialization | `bool` | `false` | no |
 | <a name="input_volume_size"></a> [volume\_size](#input\_volume\_size) | Size of the sidecar disk | `number` | `15` | no |
 | <a name="input_vpc_id"></a> [vpc\_id](#input\_vpc\_id) | AWS VPC ID to deploy sidecar to | `string` | n/a | yes |
 

--- a/ec2_locals.tf
+++ b/ec2_locals.tf
@@ -12,6 +12,7 @@ locals {
     ) : (
     length(aws_route53_record.cyral-sidecar-dns-record) == 1 ? aws_route53_record.cyral-sidecar-dns-record[0].fqdn : aws_lb.cyral-lb.dns_name
   )
+  curl                      = var.tls_skip_verify ? "curl -k" : "curl"
   name_prefix               = var.name_prefix == "" ? "cyral-${substr(lower(var.sidecar_id), -6, -1)}" : var.name_prefix
   cloudwatch_log_group_name = var.cloudwatch_log_group_name == "" ? local.name_prefix : var.cloudwatch_log_group_name
 
@@ -21,6 +22,7 @@ locals {
     controlplane_host                     = var.control_plane
     container_registry                    = var.container_registry
     container_registry_username           = var.container_registry_username
+    curl                                  = local.curl
     sidecar_endpoint                      = local.sidecar_endpoint
     dd_api_key                            = var.dd_api_key
     aws_region                            = local.aws_region

--- a/ec2_locals.tf
+++ b/ec2_locals.tf
@@ -50,6 +50,7 @@ locals {
       aws_secretsmanager_secret.sidecar_ca_certificate.arn
     )
     sidecar_ca_certificate_role_arn = var.sidecar_ca_certificate_role_arn
+    tls_skip_verify                 = var.tls_skip_verify ? "tls-skip-verify" : "tls"
   }
 
   cloud_init_func = templatefile("${path.module}/files/cloud-init-functions.sh.tmpl", local.templatevars)

--- a/files/cloud-init-functions.sh.tmpl
+++ b/files/cloud-init-functions.sh.tmpl
@@ -7,7 +7,7 @@ function package_install(){
 function docker_compose_install(){
     # Compose Setup
     sudo mkdir -p /usr/local/lib/docker/cli-plugins/
-    sudo curl -SsfL https://github.com/docker/compose/releases/latest/download/docker-compose-linux-x86_64 -o /usr/local/lib/docker/cli-plugins/docker-compose
+    sudo ${curl} -SsfL https://github.com/docker/compose/releases/latest/download/docker-compose-linux-x86_64 -o /usr/local/lib/docker/cli-plugins/docker-compose
     sudo chmod +x /usr/local/lib/docker/cli-plugins/docker-compose
 }
 
@@ -116,8 +116,8 @@ function load_idp_certs() {
 
 function fetch_hostname() {
     echo "Fetching public hostname..."
-    INSTANCE_ID=$(curl -sf -H "X-aws-ec2-metadata-token: $( \
-        curl -sf -X PUT "http://169.254.169.254/latest/api/token" -H "X-aws-ec2-metadata-token-ttl-seconds: 21600" \
+    INSTANCE_ID=$(${curl} -sf -H "X-aws-ec2-metadata-token: $( \
+        ${curl} -sf -X PUT "http://169.254.169.254/latest/api/token" -H "X-aws-ec2-metadata-token-ttl-seconds: 21600" \
         )" http://169.254.169.254/latest/meta-data/instance-id || echo "$HOSTNAME")
     echo "Setting INSTANCE_ID to '$INSTANCE_ID'"
 }
@@ -130,7 +130,7 @@ function update_nginx_resolver(){
 function get_token () {
     echo "Getting Control Plane Token using port $1..."
     local url_token="https://${controlplane_host}:$1/v1/users/oidc/token"
-    token=$(curl --no-progress-meter --fail-with-body --request POST "$url_token" -d grant_type=client_credentials -d client_id="$${SIDECAR_CLIENT_ID}" -d client_secret="$${SIDECAR_CLIENT_SECRET}" 2>&1)
+    token=$(${curl} --no-progress-meter --fail-with-body --request POST "$url_token" -d grant_type=client_credentials -d client_id="$${SIDECAR_CLIENT_ID}" -d client_secret="$${SIDECAR_CLIENT_SECRET}" 2>&1)
     token_error=$(echo $?)
 }
 
@@ -151,7 +151,7 @@ function download_sidecar () {
     access_token=$(echo "$token" | jq -r .access_token)
     url="https://${controlplane_host}/deploy/docker-compose?TemplateVersion=${sidecar_version}&TemplateType=terraform&LogIntegration=${log_integration}&MetricsIntegration=${metrics_integration}&HCVaultIntegrationID=${hc_vault_integration_id}&WiresEnabled=${repositories_supported}"
     echo "Trying to download the sidecar template from: $url"
-    if ! curl -fsS --no-progress-meter -o /home/ec2-user/sidecar.compose.yaml -L "$url" -H "Authorization: Bearer $access_token"; then
+    if ! ${curl} -fsS --no-progress-meter -o /home/ec2-user/sidecar.compose.yaml -L "$url" -H "Authorization: Bearer $access_token"; then
         echo "Unable to download compose file for version ${sidecar_version}, please make sure all parameters are correct"
         return 1
     fi

--- a/files/cloud-init-pre.sh.tmpl
+++ b/files/cloud-init-pre.sh.tmpl
@@ -25,6 +25,7 @@ LOG_GROUP_NAME=${log_group_name}
 
 LOG_INTEGRATION=${log_integration}
 METRICS_INTEGRATION=${metrics_integration}
+TLS_SKIP_VERIFY=${tls_skip_verify}
 
 NGINX_RESOLVER=$NGINX_RESOLVER
 SSO_LOGIN_URL=${idp_sso_login_url}

--- a/variables_sidecar.tf
+++ b/variables_sidecar.tf
@@ -159,3 +159,9 @@ variable "cloudwatch_log_group_name" {
   type        = string
   default     = ""
 }
+
+variable "tls_skip_verify" {
+  description = "(Optional) Skip TLS verification when communicating with the control plane"
+  type        = bool
+  default     = false
+}

--- a/variables_sidecar.tf
+++ b/variables_sidecar.tf
@@ -161,7 +161,7 @@ variable "cloudwatch_log_group_name" {
 }
 
 variable "tls_skip_verify" {
-  description = "(Optional) Skip TLS verification when communicating with the control plane"
+  description = "(Optional) Skip TLS verification for HTTPS communication with the control plane and during sidecar initialization"
   type        = bool
   default     = false
 }


### PR DESCRIPTION
In this PR we will:

- Add a boolean variable tls_skip_verify to Terraform that will set an environment variable TLS_SKIP_VERIFY=tls-skip-verify (if true) or TLS_SKIP_VERIFY=tls (if false).

We need this to pass this var over to forward-proxy, giving more flexibility in the TLS verification