### PR TITLE
Make Terraform module for AWS EC2 v3 compatible with `~> v4.7` sidecars

### DIFF
--- a/cloudwatch_resources.tf
+++ b/cloudwatch_resources.tf
@@ -1,4 +1,4 @@
 resource "aws_cloudwatch_log_group" "cyral-sidecar-lg" {
-  name              = local.name_prefix
+  name              = local.cloudwatch_log_group_name
   retention_in_days = var.cloudwatch_logs_retention
 }

--- a/ec2_locals.tf
+++ b/ec2_locals.tf
@@ -12,9 +12,10 @@ locals {
     ) : (
     length(aws_route53_record.cyral-sidecar-dns-record) == 1 ? aws_route53_record.cyral-sidecar-dns-record[0].fqdn : aws_lb.cyral-lb.dns_name
   )
-  protocol    = var.external_tls_type == "no-tls" ? "http" : "https"
-  curl        = var.external_tls_type == "tls-skip-verify" ? "curl -k" : "curl"
-  name_prefix = var.name_prefix == "" ? "cyral-${substr(lower(var.sidecar_id), -6, -1)}" : var.name_prefix
+  protocol                  = var.external_tls_type == "no-tls" ? "http" : "https"
+  curl                      = var.external_tls_type == "tls-skip-verify" ? "curl -k" : "curl"
+  name_prefix               = var.name_prefix == "" ? "cyral-${substr(lower(var.sidecar_id), -6, -1)}" : var.name_prefix
+  cloudwatch_log_group_name = var.cloudwatch_log_group_name == "" ? local.name_prefix : var.cloudwatch_log_group_name
 
   templatevars = {
     sidecar_id                            = var.sidecar_id
@@ -54,6 +55,7 @@ locals {
     sidecar_version                       = var.sidecar_version
     repositories_supported                = join(",", var.repositories_supported)
     metrics_port                          = var.metrics_port
+    cloudwatch_log_group_name             = local.cloudwatch_log_group_name
     sidecar_tls_certificate_secret_arn = (
       var.sidecar_tls_certificate_secret_arn != "" ?
       var.sidecar_tls_certificate_secret_arn :

--- a/ec2_resources.tf
+++ b/ec2_resources.tf
@@ -16,7 +16,8 @@ resource "aws_launch_template" "cyral_sidecar_lt" {
   instance_type = var.instance_type
   key_name      = var.key_name
   iam_instance_profile {
-    name = aws_iam_instance_profile.sidecar_profile.name
+    # instance profile name should be the same as sidecar_custom_host_role when a custom role is provided
+    name = local.create_sidecar_role ? aws_iam_instance_profile.sidecar_profile[0].name : var.sidecar_custom_host_role
   }
   network_interfaces {
     device_index                = 0

--- a/files/cloud-init-pre.sh.tmpl
+++ b/files/cloud-init-pre.sh.tmpl
@@ -115,6 +115,50 @@ SIDECAR_IDP_PRIVATE_KEY="$(aws secretsmanager get-secret-value --secret-id ${sec
     --region ${aws_region} | jq -r .sidecarPrivateIdpKey)"
 mkdir -p /home/ec2-user/cyral/
 
+function extract_key_from_json_input() {
+  # Both key and tls.key are valid JSON keys for private keys.
+  # Values can be PEM strings or base64-encoded PEM strings.
+  jq -r '
+    (if has("key") then .key else ."tls.key" end) as $key |
+    if ($key | startswith("-----BEGIN")) then $key else ($key | @base64d) end
+  '
+}
+
+function extract_cert_from_json_input() {
+  # Both cert and tls.crt are valid JSON keys for certificates.
+  # Values can be PEM strings or base64-encoded PEM strings.
+  jq -r '
+    (if has("cert") then .cert else ."tls.crt" end) as $cert |
+    if ($cert | startswith("-----BEGIN")) then $cert else ($cert | @base64d) end
+  '
+}
+
+function get_secret_value() {
+  secret_arn="$1"
+  role_arn="$2"
+  [ -z "$secret_arn" ] && return
+  (
+    if [ -n "$role_arn" ]; then
+      assume_role_result="$(aws sts assume-role --role-arn $role_arn --role-session-name cyral-sidecar)"
+      export AWS_ACCESS_KEY_ID=$(echo "$assume_role_result" | jq -r .Credentials.AccessKeyId)
+      export AWS_SECRET_ACCESS_KEY=$(echo "$assume_role_result" | jq -r .Credentials.SecretAccessKey)
+      export AWS_SESSION_TOKEN=$(echo "$assume_role_result" | jq -r .Credentials.SessionToken)
+    fi
+    aws --region ${aws_region} secretsmanager get-secret-value --secret-id $secret_arn --query SecretString --output text
+  )
+}
+
+SIDECAR_TLS_CERT_SECRET_VALUE=$(
+  get_secret_value "${sidecar_tls_certificate_secret_arn}" "${sidecar_tls_certificate_role_arn}"
+)
+SIDECAR_CA_CERT_SECRET_VALUE=$(
+  get_secret_value "${sidecar_ca_certificate_secret_arn}" "${sidecar_ca_certificate_role_arn}"
+)
+SIDECAR_TLS_KEY=$(echo "$SIDECAR_TLS_CERT_SECRET_VALUE" | extract_key_from_json_input | base64 -w 0)
+SIDECAR_TLS_CERT=$(echo "$SIDECAR_TLS_CERT_SECRET_VALUE" | extract_cert_from_json_input | base64 -w 0)
+SIDECAR_CA_KEY=$(echo "$SIDECAR_CA_CERT_SECRET_VALUE" | extract_key_from_json_input | base64 -w 0)
+SIDECAR_CA_CERT=$(echo "$SIDECAR_CA_CERT_SECRET_VALUE" | extract_cert_from_json_input | base64 -w 0)
+
 echo "Initializing environment variables..."
 cat > /home/ec2-user/.env << EOF
 SIDECAR_ID=${sidecar_id}
@@ -158,8 +202,10 @@ MYSQL_MULTIPLEXED_PORT=${mysql_multiplexed_port}
 
 LOAD_BALANCER_TLS_PORTS=${load_balancer_tls_ports}
 
-CYRAL_CERTIFICATE_MANAGER_SELFSIGNED_SECRET_ID=${sidecar_created_certificate_secret_id}
-CYRAL_CERTIFICATE_MANAGER_SELFSIGNED_SECRET_TYPE=aws
+CYRAL_CERTIFICATE_MANAGER_TLS_KEY=$${SIDECAR_TLS_KEY}
+CYRAL_CERTIFICATE_MANAGER_TLS_CERT=$${SIDECAR_TLS_CERT}
+CYRAL_CERTIFICATE_MANAGER_CA_KEY=$${SIDECAR_CA_KEY}
+CYRAL_CERTIFICATE_MANAGER_CA_CERT=$${SIDECAR_CA_CERT}
 
 METRICS_PORT=${metrics_port}
 EOF

--- a/files/cloud-init-pre.sh.tmpl
+++ b/files/cloud-init-pre.sh.tmpl
@@ -120,7 +120,7 @@ function extract_key_from_json_input() {
   # Values can be PEM strings or base64-encoded PEM strings.
   jq -r '
     (if has("key") then .key else ."tls.key" end) as $key |
-    if ($key | startswith("-----BEGIN")) then $key else ($key | @base64d) end
+    if ($key | startswith("-----BEGIN")) then $key else ($key | gsub("\\s+"; "") | @base64d) end
   '
 }
 
@@ -129,7 +129,7 @@ function extract_cert_from_json_input() {
   # Values can be PEM strings or base64-encoded PEM strings.
   jq -r '
     (if has("cert") then .cert else ."tls.crt" end) as $cert |
-    if ($cert | startswith("-----BEGIN")) then $cert else ($cert | @base64d) end
+    if ($cert | startswith("-----BEGIN")) then $cert else ($cert | gsub("\\s+"; "") | @base64d) end
   '
 }
 

--- a/files/self-signed-certificate-lambda/index.py
+++ b/files/self-signed-certificate-lambda/index.py
@@ -1,0 +1,127 @@
+import logging
+import json
+import secrets
+
+import boto3
+from OpenSSL import crypto
+
+KEY_SIZE = 4096
+CERT_DURATION = 10*365*24*60*60
+CERT_COUNTRY = "US"
+CERT_PROVINCE = "CA"
+CERT_LOCALITY = "Redwood City"
+CERT_ORGANIZATION = "Cyral Inc."
+CERT_DEFAULT_HOST = "sidecar.app.cyral.com"
+
+logger = logging.getLogger()
+logger.setLevel(logging.INFO)
+secrets_client = boto3.client('secretsmanager')
+
+def handler(event, context):
+  try:
+    logger.info('Received event: {}'.format(json.dumps(event)))
+
+    secret_id = event.get('SecretId')
+    if not secret_id:
+      logger.error('SecretId is empty')
+      return {'statusCode': 400}
+
+    hostname = event.get('Hostname', CERT_DEFAULT_HOST)
+    is_ca_certificate = event.get('IsCACertificate', False)
+    update_secret_if_needed(secret_id, hostname, is_ca_certificate)
+    return {'statusCode': 200}
+  except Exception as e:
+    logger.error('Error: {}'.format(e))
+    return {'statusCode': 400}
+
+def update_secret_if_needed(secret_id, hostname, is_ca_certificate=False):
+  current_value = None
+  try:
+    current_value = secrets_client.get_secret_value(
+      SecretId=secret_id
+    ).get('SecretString')
+  except secrets_client.exceptions.ResourceNotFoundException as err:
+    logger.info('Secret is empty, so a new certificate will be generated')
+  if current_value:
+    # do not update the secret if it already has a value
+    return
+  key_pem, cert_pem = generate_self_signed_cert(
+    hostname,
+    is_ca_certificate=is_ca_certificate,
+  )
+  secret_string = json.dumps({
+    'key':key_pem,
+    'cert':cert_pem,
+  })
+  secrets_client.update_secret(
+    SecretId=secret_id,
+    SecretString=secret_string
+  )
+
+def generate_self_signed_cert(
+  hostname,
+  is_ca_certificate=False,
+):
+  key = crypto.PKey()
+  key.generate_key(crypto.TYPE_RSA, KEY_SIZE)
+  private_key_pem = crypto.dump_privatekey(crypto.FILETYPE_PEM, key).decode('utf-8')
+
+  ca_cert = crypto.X509()
+  ca_cert.set_version(2)
+  ca_cert.set_serial_number(secrets.randbits(128))
+  ca_subj = ca_cert.get_subject()
+  ca_subj.C = CERT_COUNTRY
+  ca_subj.ST = CERT_PROVINCE
+  ca_subj.L = CERT_LOCALITY
+  ca_subj.O = CERT_ORGANIZATION
+  ca_cert.add_extensions([
+      crypto.X509Extension(b"subjectKeyIdentifier", False, b"hash", subject=ca_cert),
+  ])
+  ca_cert.add_extensions([
+      crypto.X509Extension(b"authorityKeyIdentifier", False, b"keyid:always", issuer=ca_cert),
+  ])
+  ca_cert.add_extensions([
+      crypto.X509Extension(b"basicConstraints", False, b"CA:TRUE"),
+      crypto.X509Extension(b"keyUsage", False, b"keyCertSign, cRLSign"),
+  ])
+  ca_cert.set_issuer(ca_subj)
+  ca_cert.set_pubkey(key)
+  ca_cert.sign(key, 'sha256')
+  ca_cert.gmtime_adj_notBefore(0)
+  ca_cert.gmtime_adj_notAfter(CERT_DURATION)
+  ca_certificate_pem = crypto.dump_certificate(crypto.FILETYPE_PEM, ca_cert).decode('utf-8')
+  if is_ca_certificate:
+    return (private_key_pem, ca_certificate_pem)
+
+  # Create Self-Signed Certificate
+  client_cert = crypto.X509()
+  client_cert.set_version(2)
+  client_cert.set_serial_number(secrets.randbits(128))
+  client_subj = client_cert.get_subject()
+  client_subj.C = CERT_COUNTRY
+  client_subj.ST = CERT_PROVINCE
+  client_subj.L = CERT_LOCALITY
+  client_subj.O = CERT_ORGANIZATION
+  client_subj.CN = hostname
+  client_cert.add_extensions([
+      crypto.X509Extension(b"basicConstraints", False, b"CA:FALSE"),
+      crypto.X509Extension(b"subjectKeyIdentifier", False, b"hash", subject=client_cert),
+  ])
+  client_cert.add_extensions([
+      crypto.X509Extension(b"authorityKeyIdentifier", False, b"keyid:always", issuer=ca_cert),
+      crypto.X509Extension(b"extendedKeyUsage", False, b"serverAuth"),
+      crypto.X509Extension(b"keyUsage", False, b"digitalSignature"),
+  ])
+  client_cert.add_extensions([
+      crypto.X509Extension(b'subjectAltName', False,
+          ','.join([
+              f'DNS:*.{hostname}'
+  ]).encode())])
+  client_cert.set_issuer(ca_subj)
+  client_cert.set_pubkey(key)
+  client_cert.gmtime_adj_notBefore(0)
+  client_cert.gmtime_adj_notAfter(CERT_DURATION)
+  client_cert.sign(key, 'sha256')
+  certifictate_pem = crypto.dump_certificate(crypto.FILETYPE_PEM, client_cert).decode('utf-8')
+
+  return (private_key_pem, certifictate_pem)

--- a/iam_resources.tf
+++ b/iam_resources.tf
@@ -1,6 +1,7 @@
 locals {
   create_custom_certificate_role = var.sidecar_custom_certificate_account_id != ""
   create_kms_policy              = var.ec2_ebs_kms_arn != "" || var.secrets_kms_arn != ""
+  create_sidecar_role            = var.sidecar_custom_host_role == ""
 }
 
 # Gets the ARN from a resource that is deployed by this module in order to
@@ -44,13 +45,53 @@ data "aws_iam_policy_document" "init_script_policy" {
       "arn:${data.aws_arn.cw_lg.partition}:secretsmanager:${data.aws_arn.cw_lg.region}:${data.aws_arn.cw_lg.account}:secret:${var.secrets_location}*"
     ])
   }
-  statement {
-    actions = [
-      "secretsmanager:UpdateSecret"
-    ]
-    resources = [
-      "arn:${data.aws_arn.cw_lg.partition}:secretsmanager:${data.aws_arn.cw_lg.region}:${data.aws_arn.cw_lg.account}:secret:/cyral/sidecars/${var.sidecar_id}/self-signed-certificate*"
-    ]
+
+  dynamic "statement" {
+    for_each = (var.sidecar_tls_certificate_secret_arn != "" && var.sidecar_tls_certificate_role_arn == "") ? [1] : []
+    content {
+      actions = [
+        "secretsmanager:GetSecretValue"
+      ]
+      resources = compact([
+        var.sidecar_tls_certificate_secret_arn,
+      ])
+    }
+  }
+
+  dynamic "statement" {
+    for_each = (var.sidecar_ca_certificate_secret_arn != "" && var.sidecar_ca_certificate_role_arn == "") ? [1] : []
+    content {
+      actions = [
+        "secretsmanager:GetSecretValue"
+      ]
+      resources = compact([
+        var.sidecar_ca_certificate_secret_arn,
+      ])
+    }
+  }
+
+  dynamic "statement" {
+    for_each = (var.sidecar_tls_certificate_secret_arn != "" && var.sidecar_tls_certificate_role_arn != "") ? [1] : []
+    content {
+      actions = [
+        "sts:AssumeRole"
+      ]
+      resources = compact([
+        var.sidecar_tls_certificate_role_arn,
+      ])
+    }
+  }
+
+  dynamic "statement" {
+    for_each = (var.sidecar_ca_certificate_secret_arn != "" && var.sidecar_ca_certificate_role_arn != "") ? [1] : []
+    content {
+      actions = [
+        "sts:AssumeRole"
+      ]
+      resources = compact([
+        var.sidecar_ca_certificate_role_arn,
+      ])
+    }
   }
 
   source_policy_documents = [
@@ -87,11 +128,13 @@ data "aws_iam_policy_document" "sidecar" {
 }
 
 resource "aws_iam_instance_profile" "sidecar_profile" {
+  count = local.create_sidecar_role ? 1 : 0
   name = "${local.name_prefix}-sidecar_profile"
-  role = aws_iam_role.sidecar_role.name
+  role = local.create_sidecar_role ? aws_iam_role.sidecar_role[0].name : var.sidecar_custom_host_role
 }
 
 resource "aws_iam_role" "sidecar_role" {
+  count              = local.create_sidecar_role ? 1 : 0
   name               = "${local.name_prefix}-sidecar_role"
   path               = "/"
   assume_role_policy = data.aws_iam_policy_document.sidecar.json
@@ -105,13 +148,13 @@ resource "aws_iam_policy" "init_script_policy" {
 }
 
 resource "aws_iam_role_policy_attachment" "init_script_policy" {
-  role       = aws_iam_role.sidecar_role.name
+  role       = local.create_sidecar_role ? aws_iam_role.sidecar_role[0].name : var.sidecar_custom_host_role
   policy_arn = aws_iam_policy.init_script_policy.arn
 }
 
 resource "aws_iam_role_policy_attachment" "user_policies" {
   count      = length(var.iam_policies)
-  role       = aws_iam_role.sidecar_role.name
+  role       = local.create_sidecar_role ? aws_iam_role.sidecar_role[0].name : var.sidecar_custom_host_role
   policy_arn = var.iam_policies[count.index]
 }
 
@@ -135,7 +178,6 @@ data "aws_iam_policy_document" "sidecar_custom_certificate_secrets_manager" {
   statement {
     actions = [
       "secretsmanager:GetSecretValue",
-      "secretsmanager:UpdateSecret"
     ]
     resources = [aws_secretsmanager_secret.sidecar_custom_certificate[0].id]
   }
@@ -159,4 +201,49 @@ resource "aws_iam_role_policy_attachment" "sidecar_custom_certificate" {
   count      = local.create_custom_certificate_role ? 1 : 0
   role       = aws_iam_role.sidecar_custom_certificate[0].name
   policy_arn = aws_iam_policy.sidecar_custom_certificate_secrets_manager[0].arn
+}
+
+resource "aws_iam_role" "self_signed_certificate" {
+  name = "${local.name_prefix}-self_signed_certificate_role"
+  path = "/"
+  assume_role_policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Action = "sts:AssumeRole"
+        Effect = "Allow"
+        Principal = {
+          Service = "lambda.amazonaws.com"
+        }
+      },
+    ]
+  })
+  inline_policy {
+    name = "CertificateManagerLambdaPolicy"
+    policy = jsonencode({
+      Version = "2012-10-17"
+      Statement = [
+        {
+          Effect = "Allow"
+          Action = [
+            "logs:CreateLogGroup",
+            "logs:CreateLogStream",
+            "logs:PutLogEvents",
+          ]
+          Resource = "arn:${local.aws_partition}:logs:${local.aws_region}:${local.aws_account_id}:*"
+        },
+        {
+          Effect = "Allow"
+          Action = [
+            "secretsmanager:GetSecretValue",
+            "secretsmanager:UpdateSecret",
+          ]
+          Resource = [
+            "arn:${local.aws_partition}:secretsmanager:${local.aws_region}:${local.aws_account_id}:secret:/cyral/sidecars/${var.sidecar_id}/self-signed-certificate*",
+            "arn:${local.aws_partition}:secretsmanager:${local.aws_region}:${local.aws_account_id}:secret:/cyral/sidecars/${var.sidecar_id}/ca-certificate*",
+          ]
+        },
+      ]
+    })
+  }
 }

--- a/output.tf
+++ b/output.tf
@@ -14,7 +14,7 @@ output "sidecar_load_balancer_dns" {
 }
 
 output "aws_iam_role_arn" {
-  value       = aws_iam_role.sidecar_role.arn
+  value       = local.create_sidecar_role ? aws_iam_role.sidecar_role[0].arn : null
   description = "Sidecar IAM role ARN"
 }
 
@@ -39,4 +39,9 @@ output "sidecar_custom_certificate_role_arn" {
     null
   )
   description = "IAM role ARN to use in the Sidecar Custom Certificate modules."
+}
+
+output "aws_cloudwatch_log_group_name" {
+  value       = aws_cloudwatch_log_group.cyral-sidecar-lg.name
+  description = "Name of the CloudWatch log group where sidecar logs are stored."
 }

--- a/secretsmanager_resources.tf
+++ b/secretsmanager_resources.tf
@@ -7,6 +7,8 @@ locals {
     sidecarPrivateIdpKey        = replace(var.sidecar_private_idp_key, "\n", "\\n")
   }
   create_sidecar_custom_certificate_secret = var.sidecar_custom_certificate_account_id != ""
+  sidecar_created_certificate_secret_name  = "/cyral/sidecars/${var.sidecar_id}/self-signed-certificate"
+  sidecar_ca_certificate_secret_name       = "/cyral/sidecars/${var.sidecar_id}/ca-certificate"
 }
 
 resource "aws_secretsmanager_secret" "cyral-sidecar-secret" {
@@ -23,8 +25,15 @@ resource "aws_secretsmanager_secret_version" "cyral-sidecar-secret-version" {
 }
 
 resource "aws_secretsmanager_secret" "sidecar_created_certificate" {
-  name                    = "/cyral/sidecars/${var.sidecar_id}/self-signed-certificate"
+  name                    = local.sidecar_created_certificate_secret_name
   description             = "Self-signed TLS certificate used by sidecar in case a custom certificate is not provided."
+  recovery_window_in_days = 0
+  kms_key_id              = var.secrets_kms_arn
+}
+
+resource "aws_secretsmanager_secret" "sidecar_ca_certificate" {
+  name                    = local.sidecar_ca_certificate_secret_name
+  description             = "CA certificate used by sidecar in case a custom CA certificate is not provided."
   recovery_window_in_days = 0
   kms_key_id              = var.secrets_kms_arn
 }
@@ -35,4 +44,42 @@ resource "aws_secretsmanager_secret" "sidecar_custom_certificate" {
   description             = "Custom certificate used by Cyral sidecar for TLS. This secret will be controlled by the Sidecar Custom Certificate module."
   recovery_window_in_days = 0
   kms_key_id              = var.secrets_kms_arn
+}
+
+data "archive_file" "self_signed_certificate_lambda" {
+  type        = "zip"
+  source_dir  = "${path.module}/files/self-signed-certificate-lambda"
+  output_path = "${path.module}/files/self-signed-certificate-lambda.zip"
+}
+
+resource "aws_lambda_function" "self_signed_certificate" {
+  function_name    = "${local.name_prefix}-self_signed_certificate"
+  description      = "Generates certificates for the sidecar when needed"
+  role             = aws_iam_role.self_signed_certificate.arn
+  runtime          = "python3.10"
+  filename         = data.archive_file.self_signed_certificate_lambda.output_path
+  source_code_hash = data.archive_file.self_signed_certificate_lambda.output_base64sha256
+  handler          = "index.handler"
+  layers = [
+    "arn:aws:lambda:${local.aws_region}:155826672581:layer:pyopenssl:1"
+  ]
+  timeout = 120
+}
+
+resource "aws_lambda_invocation" "self_signed_tls_certificate" {
+  function_name = aws_lambda_function.self_signed_certificate.function_name
+  input = jsonencode({
+    SecretId        = aws_secretsmanager_secret.sidecar_created_certificate.id
+    Hostname        = local.sidecar_endpoint
+    IsCACertificate = false
+  })
+}
+
+resource "aws_lambda_invocation" "self_signed_ca_certificate" {
+  function_name = aws_lambda_function.self_signed_certificate.function_name
+  input = jsonencode({
+    SecretId        = aws_secretsmanager_secret.sidecar_ca_certificate.id
+    Hostname        = local.sidecar_endpoint
+    IsCACertificate = true
+  })
 }

--- a/variables_sidecar.tf
+++ b/variables_sidecar.tf
@@ -170,3 +170,33 @@ variable "custom_user_data" {
   type        = map(any)
   default     = { "pre" = "", "post" = "" }
 }
+
+variable "sidecar_tls_certificate_secret_arn" {
+  description = "(Optional) ARN of secret in AWS Secrets Manager that contains a certificate to terminate TLS connections."
+  type        = string
+  default     = ""
+}
+
+variable "sidecar_tls_certificate_role_arn" {
+  description = "(Optional) ARN of an AWS IAM Role to assume when reading the TLS certificate."
+  type        = string
+  default     = ""
+}
+
+variable "sidecar_ca_certificate_secret_arn" {
+  description = "(Optional) ARN of secret in AWS Secrets Manager that contains a CA certificate to sign sidecar-generated certs."
+  type        = string
+  default     = ""
+}
+
+variable "sidecar_ca_certificate_role_arn" {
+  description = "(Optional) ARN of an AWS IAM Role to assume when reading the CA certificate."
+  type        = string
+  default     = ""
+}
+
+variable "sidecar_custom_host_role" {
+  description = "(Optional) Name of an AWS IAM Role to attach to the EC2 instance profile."
+  type        = string
+  default     = ""
+}

--- a/variables_sidecar.tf
+++ b/variables_sidecar.tf
@@ -200,3 +200,9 @@ variable "sidecar_custom_host_role" {
   type        = string
   default     = ""
 }
+
+variable "cloudwatch_log_group_name" {
+  description = "(Optional) Cloudwatch log group name."
+  type        = string
+  default     = ""
+}

--- a/variables_sidecar.tf
+++ b/variables_sidecar.tf
@@ -151,7 +151,7 @@ variable "sidecar_ports" {
 variable "metrics_port" {
   description = "Port which will respond with metrics on the sidecar"
   type        = number
-  default     = 9000
+  default     = 8888
 }
 
 variable "sidecar_version" {

--- a/versions.tf
+++ b/versions.tf
@@ -1,9 +1,17 @@
 terraform {
   required_version = ">= 0.12"
   required_providers {
+    archive = {
+      source  = "hashicorp/archive"
+      version = "2.3.0"
+    }
     aws = {
       version = ">= 3.73.0"
       source  = "hashicorp/aws"
+    }
+    tls = {
+      version = ">= 4.0.4"
+      source  = "hashicorp/tls"
     }
   }
 }


### PR DESCRIPTION
In this PR we plan to:

- Add a new environment variable to instruct service-monitor to use port 8888 for health checks.

- Create the new CA certificate:  https://github.com/cyralinc/terraform-aws-sidecar-ec2/commit/e2d50c3f1d1e1f06e38dc415b75a3f55392fb560  and  https://github.com/cyralinc/terraform-aws-sidecar-ec2/commit/01cdb9b89e636a4071800de77536dac71edb3579

- Add the parameter to set a name for the CloudWatch log group: https://github.com/cyralinc/terraform-aws-sidecar-ec2/commit/c30d35656c0388c9787e3d6d09185cc67b243387
 

