### PR TITLE
ENG-12327: Add consistency in case of `custom_user_data` variable does not contain all keys

### DIFF
--- a/ec2_resources.tf
+++ b/ec2_resources.tf
@@ -46,11 +46,11 @@ resource "aws_launch_template" "cyral_sidecar_lt" {
   user_data = base64encode(<<-EOT
   #!/bin/bash -e
   ${local.cloud_init_func}
-  ${lookup(var.custom_user_data, "pre")}
+  ${try(lookup(var.custom_user_data, "pre"), "")}
   ${local.cloud_init_pre}
-  ${lookup(var.custom_user_data, "pre_sidecar_start")}
+  ${try(lookup(var.custom_user_data, "pre_sidecar_start"), "")}
   ${local.cloud_init_post}
-  ${lookup(var.custom_user_data, "post")}
+  ${try(lookup(var.custom_user_data, "post"), "")}
 EOT
   )
   lifecycle {

--- a/variables_sidecar.tf
+++ b/variables_sidecar.tf
@@ -120,8 +120,16 @@ variable "repositories_supported" {
 
 variable "custom_user_data" {
   description = "Ancillary consumer supplied user-data script. Bash scripts must be added to a map as a value of the key `pre`, `pre_sidecar_start`, `post` denoting execution order with respect to sidecar installation. (Approx Input Size = 19KB)"
-  type        = map(any)
-  default     = { "pre" = "", "pre_sidecar_start" = "", "post" = "" }
+  type = object({
+    pre               = string
+    pre_sidecar_start = string
+    post              = string
+  })
+  default = {
+    pre               = ""
+    pre_sidecar_start = ""
+    post              = ""
+  }
 }
 
 variable "sidecar_tls_certificate_secret_arn" {

--- a/variables_sidecar.tf
+++ b/variables_sidecar.tf
@@ -120,16 +120,8 @@ variable "repositories_supported" {
 
 variable "custom_user_data" {
   description = "Ancillary consumer supplied user-data script. Bash scripts must be added to a map as a value of the key `pre`, `pre_sidecar_start`, `post` denoting execution order with respect to sidecar installation. (Approx Input Size = 19KB)"
-  type = object({
-    pre               = string
-    pre_sidecar_start = string
-    post              = string
-  })
-  default = {
-    pre               = ""
-    pre_sidecar_start = ""
-    post              = ""
-  }
+  type        = map(any)
+  default     = { "pre" = "", "pre_sidecar_start" = "", "post" = "" }
 }
 
 variable "sidecar_tls_certificate_secret_arn" {


### PR DESCRIPTION
The Terraform module for AWS EC2 sidecars should have a consistency to avoid erroring out in case the variable custom_user_data is provided and does not contain all the keys pre, post and pre_sidecar_start.

In case the provided map does not have any of these keys, it will fail in the lookup calls [in this section of code](https://github.com/cyralinc/terraform-aws-sidecar-ec2/blob/main/ec2_resources.tf#L49-L53).


Test:

using  `source = "git@github.com:cyralinc/terraform-aws-sidecar-ec2.git?ref=ENG-12327"` in the module, I tried 

By not declaring the `custom_user_data` it works just fine: (as the default is a correct object)
![image](https://github.com/cyralinc/terraform-aws-sidecar-ec2/assets/37452507/e7991aa4-56e1-4686-97db-5812889d11fc)

Using the object:
```
  custom_user_data = {
    post               = "echo 'post-commands'"
  }
```
I created the sidecar and it's working fine:
![image](https://github.com/cyralinc/terraform-aws-sidecar-ec2/assets/37452507/cf8e7f68-203e-4bef-bce8-51fefdf6aaeb)
![image](https://github.com/cyralinc/terraform-aws-sidecar-ec2/assets/37452507/674fe497-60de-49fd-86d5-cd67d6a6f2b1)
by converting b64 message we see the post commands echo along with the default code
![image](https://github.com/cyralinc/terraform-aws-sidecar-ec2/assets/37452507/6a512a66-fce0-4b7d-bc65-9c579c84430d)
By entering the sidecar I can see the message also:
![image](https://github.com/cyralinc/terraform-aws-sidecar-ec2/assets/37452507/44ec7397-f141-47bb-ae78-538f3d644dbd)
![image](https://github.com/cyralinc/terraform-aws-sidecar-ec2/assets/37452507/a52b9f7d-8d28-4553-9b7a-13ba19a8c38a)
![image](https://github.com/cyralinc/terraform-aws-sidecar-ec2/assets/37452507/55026ef3-5cb1-4ea1-91fc-26c1c736ec1e)

