### PR TITLE
ENG-12268: Make container registry info optional

### DIFF
--- a/variables_sidecar.tf
+++ b/variables_sidecar.tf
@@ -1,10 +1,7 @@
 variable "container_registry" {
   description = "Address of the container registry where Cyral images are stored"
   type        = string
-  validation {
-    condition     = length(var.container_registry) > 0
-    error_message = "The container registry must not be empty"
-  }
+  default     = "<PUBLIC_CYRAL_ACCOUNT_ID>.dkr.ecr.us-east-1.amazonaws.com"
 }
 
 variable "container_registry_username" {


### PR DESCRIPTION
Container registry name and creds should be optional, leading to Cyral public ECR if not set