### PR TITLE
ENG-12832: Making load_certs echo Warning

### DIFF
--- a/files/cloud-init-functions.sh.tmpl
+++ b/files/cloud-init-functions.sh.tmpl
@@ -97,8 +97,7 @@ function load_certs() {
     echo "Loading certificates..."
     local sidecar_tls_cert_secret_value sidecar_ca_cert_secret_value
     if ! sidecar_tls_cert_secret_value=$(get_secret_value "${sidecar_tls_certificate_secret_arn}" "${SidecarTLSCertificateRoleArn}"); then
-        echo "Unable to fetch shared TLS certificate"
-        echo "Warning: ${sidecar_tls_certificate_secret_arn}"
+        echo "WARNING: Unable to fetch shared TLS certificate from ${sidecar_tls_certificate_secret_arn} see error above"
     fi
     if ! sidecar_ca_cert_secret_value=$(get_secret_value "${sidecar_ca_certificate_secret_arn}" "${SidecarCACertificateRoleArn}"); then
         echo "WARNING: Unable to fetch shared CA certificate from ${sidecar_ca_certificate_secret_arn}" see error above.

--- a/files/cloud-init-functions.sh.tmpl
+++ b/files/cloud-init-functions.sh.tmpl
@@ -96,12 +96,14 @@ function get_secret(){
 function load_certs() {
     echo "Loading certificates..."
     local sidecar_tls_cert_secret_value sidecar_ca_cert_secret_value
-    sidecar_tls_cert_secret_value=$(
-        get_secret_value "${sidecar_tls_certificate_secret_arn}" "${sidecar_tls_certificate_role_arn}"
-    )
-    sidecar_ca_cert_secret_value=$(
-        get_secret_value "${sidecar_ca_certificate_secret_arn}" "${sidecar_ca_certificate_role_arn}"
-    )
+    if ! sidecar_tls_cert_secret_value=$(get_secret_value "${sidecar_tls_certificate_secret_arn}" "${SidecarTLSCertificateRoleArn}"); then
+        echo "Unable to fetch shared TLS certificate"
+        echo "Warning: ${sidecar_tls_certificate_secret_arn}"
+    fi
+    if ! sidecar_ca_cert_secret_value=$(get_secret_value "${sidecar_ca_certificate_secret_arn}" "${SidecarCACertificateRoleArn}"); then
+        echo "Unable to fetch shared CA certificate"
+        echo "Warning: ${sidecar_ca_certificate_secret_arn}"
+    fi
     SIDECAR_TLS_KEY=$(echo "$sidecar_tls_cert_secret_value" | extract_key_from_json_input)
     SIDECAR_TLS_CERT=$(echo "$sidecar_tls_cert_secret_value" | extract_cert_from_json_input)
     SIDECAR_CA_KEY=$(echo "$sidecar_ca_cert_secret_value" | extract_key_from_json_input)

--- a/files/cloud-init-functions.sh.tmpl
+++ b/files/cloud-init-functions.sh.tmpl
@@ -101,8 +101,7 @@ function load_certs() {
         echo "Warning: ${sidecar_tls_certificate_secret_arn}"
     fi
     if ! sidecar_ca_cert_secret_value=$(get_secret_value "${sidecar_ca_certificate_secret_arn}" "${SidecarCACertificateRoleArn}"); then
-        echo "Unable to fetch shared CA certificate"
-        echo "Warning: ${sidecar_ca_certificate_secret_arn}"
+        echo "WARNING: Unable to fetch shared CA certificate from ${sidecar_ca_certificate_secret_arn}" see error above.
     fi
     SIDECAR_TLS_KEY=$(echo "$sidecar_tls_cert_secret_value" | extract_key_from_json_input)
     SIDECAR_TLS_CERT=$(echo "$sidecar_tls_cert_secret_value" | extract_cert_from_json_input)


### PR DESCRIPTION
Changes to the `load_certs` function to allow for the init script to continue if the certificate secrets have not been created.