### PR TITLE
ENG-14157: Add support for additional target groups

### DIFF
--- a/README.md
+++ b/README.md
@@ -164,7 +164,8 @@ No modules.
 
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
-| <a name="input_additional_security_groups"></a> [additional\_security\_groups](#input\_additional\_security\_groups) | Additional security groups to attach to sidecar instances | `list(string)` | `[]` | no |
+| <a name="input_additional_security_groups"></a> [additional\_security\_groups](#input\_additional\_security\_groups) | List of the IDs of the additional security groups that will be attached to the sidecar instances. If providing<br>`additional_target_groups`, use this parameter to provide security groups with the inbound rules to allow<br>inbound traffic from the target groups to the instances. | `list(string)` | `[]` | no |
+| <a name="input_additional_target_groups"></a> [additional\_target\_groups](#input\_additional\_target\_groups) | List of the ARNs of the additional target groups that will be attached to the sidecar instances. Use it in<br>conjunction with `additional_security_groups` to provide the inbound rules for the ports associated with <br>them, otherwise the incoming traffic from the target groups will not be allowed to access the EC2 instances. | `list(string)` | `[]` | no |
 | <a name="input_ami_id"></a> [ami\_id](#input\_ami\_id) | Amazon Linux 2 AMI ID for sidecar EC2 instances. The default behavior is to use the latest version.<br>In order to define a new image, provide the desired image id. | `string` | `""` | no |
 | <a name="input_asg_count"></a> [asg\_count](#input\_asg\_count) | Set to 1 to enable the ASG, 0 to disable. Only for debugging. | `number` | `1` | no |
 | <a name="input_asg_desired"></a> [asg\_desired](#input\_asg\_desired) | The desired number of hosts to create in the auto scaling group | `number` | `1` | no |

--- a/ec2_resources.tf
+++ b/ec2_resources.tf
@@ -72,7 +72,7 @@ resource "aws_autoscaling_group" "cyral-sidecar-asg" {
   max_size                  = var.deploy_load_balancer ? var.asg_max : 1
   health_check_grace_period = var.health_check_grace_period
   health_check_type         = "EC2"
-  target_group_arns         = var.deploy_load_balancer ? [for tg in aws_lb_target_group.cyral-sidecar-tg : tg.id] : []
+  target_group_arns         = var.deploy_load_balancer ? concat([for tg in aws_lb_target_group.cyral-sidecar-tg : tg.id], var.additional_target_groups) : var.additional_target_groups
 
   tag {
     key                 = "Name"

--- a/ec2_resources.tf
+++ b/ec2_resources.tf
@@ -67,9 +67,9 @@ resource "aws_autoscaling_group" "cyral-sidecar-asg" {
     version = aws_launch_template.cyral_sidecar_lt.latest_version
   }
   vpc_zone_identifier       = var.subnets
-  min_size                  = var.deploy_load_balancer ? var.asg_min : 0
-  desired_capacity          = var.deploy_load_balancer ? var.asg_desired : 1
-  max_size                  = var.deploy_load_balancer ? var.asg_max : 1
+  min_size                  = var.asg_min
+  desired_capacity          = var.asg_desired
+  max_size                  = var.asg_max
   health_check_grace_period = var.health_check_grace_period
   health_check_type         = "EC2"
   target_group_arns         = var.deploy_load_balancer ? concat([for tg in aws_lb_target_group.cyral-sidecar-tg : tg.id], var.additional_target_groups) : var.additional_target_groups

--- a/variables_aws.tf
+++ b/variables_aws.tf
@@ -193,7 +193,21 @@ variable "associate_public_ip_address" {
 }
 
 variable "additional_security_groups" {
-  description = "Additional security groups to attach to sidecar instances"
+  description = <<EOF
+List of the IDs of the additional security groups that will be attached to the sidecar instances. If providing
+`additional_target_groups`, use this parameter to provide security groups with the inbound rules to allow
+inbound traffic from the target groups to the instances.
+EOF
+  type        = list(string)
+  default     = []
+}
+
+variable "additional_target_groups" {
+  description = <<EOF
+List of the ARNs of the additional target groups that will be attached to the sidecar instances. Use it in
+conjunction with `additional_security_groups` to provide the inbound rules for the ports associated with 
+them, otherwise the incoming traffic from the target groups will not be allowed to access the EC2 instances.
+EOF
   type        = list(string)
   default     = []
 }


### PR DESCRIPTION
Add support for additional target groups.

Tested with the following Terraform script:

```hcl
terraform {
  required_providers {
    cyral = {
      source  = "cyralinc/cyral"
      version = "~> 4.7"
    }
  }
}

locals {
  # Replace [TENANT] by your tenant name. Ex: mycompany.app.cyral.com
  control_plane_host = "<SOME_CP>"

  pg = {
    address = "<SOME_DB>"
    port = 5432
  }

  external_tg_ports = [5433, 5434]

  sidecar = {
    # Set to true if you want a sidecar deployed with an
    # internet-facing load balancer (requires a public subnet).
    public_sidecar = true

    # Set the AWS region that the sidecar will be deployed to
    region = "us-east-1"
    # Set the ID of VPC that the sidecar will be deployed to
    vpc_id = ""
    # Set the IDs of the subnets that the sidecar will be deployed to
    subnets = [""]
    # Name of the CloudWatch log group used to push logs
    cloudwatch_log_group_name = "cyral-example-loggroup"

    # Set the allowed CIDR block for SSH access to the sidecar
    ssh_inbound_cidr = ["0.0.0.0/0"]
    # Set the allowed CIDR block for database access through the
    # sidecar
    db_inbound_cidr = ["0.0.0.0/0"]
    # Set the allowed CIDR block for monitoring requests to the
    # sidecar
    monitoring_inbound_cidr = ["0.0.0.0/0"]

    # Optionally set the hosted zone ID that will be used to create the
    # DNS name in parameter `dns_name`
    dns_hosted_zone_id = ""
    # Optionally set the DNS name that will be used by your sidecar. Ex:
    # sidecar.mycompany.com
    dns_name = ""
  }
}

provider "aws" {
  region = "us-east-1"
}

provider "cyral" {
   client_id     = ""
   client_secret = ""

  control_plane = local.control_plane_host
}

resource "cyral_repository" "pg" {
  name = "pgRepo"
  type = "postgresql"

  repo_node {
    host = local.pg.address
    port = local.pg.port
  }
}

resource "cyral_sidecar_listener" "pg" {
  for_each ={ for p in concat(local.external_tg_ports, [local.pg.port]) : tostring(p) => p }
  sidecar_id = cyral_sidecar.sidecar.id
  repo_types = ["postgresql"]
  network_address {
    port = each.value
  }
}

resource "cyral_repository_binding" "pg" {
  for_each ={ for p in concat(local.external_tg_ports, [local.pg.port]) : tostring(p) => p }
  sidecar_id    = cyral_sidecar.sidecar.id
  repository_id = cyral_repository.pg.id
  listener_binding {
    listener_id = cyral_sidecar_listener.pg[each.value].listener_id
  }
}

resource "cyral_sidecar" "sidecar" {
  name              = "my-sidecar"
  deployment_method = "terraform"
}

resource "cyral_sidecar_credentials" "sidecar_credentials" {
  sidecar_id = cyral_sidecar.sidecar.id
}

module "cyral_sidecar" {
  source = "github.com/cyralinc/terraform-aws-sidecar-ec2?ref=feat%2FENG-14157"

  sidecar_version = "v4.14.0"

  use_single_container = true

  sidecar_id = cyral_sidecar.sidecar.id
  control_plane = local.control_plane_host
  client_id     = cyral_sidecar_credentials.sidecar_credentials.client_id
  client_secret = cyral_sidecar_credentials.sidecar_credentials.client_secret

  sidecar_ports = [5432]

  vpc_id  = local.sidecar.vpc_id
  subnets = local.sidecar.subnets

  ssh_inbound_cidr        = local.sidecar.ssh_inbound_cidr
  db_inbound_cidr         = local.sidecar.db_inbound_cidr
  monitoring_inbound_cidr = local.sidecar.monitoring_inbound_cidr

  asg_max = 1
  asg_desired = 1

  deploy_load_balancer = true

  additional_target_groups = [for v in aws_lb_target_group.external-tg : v.arn]
  additional_security_groups = [aws_security_group.external-sg.id]

  load_balancer_scheme        = local.sidecar.public_sidecar ? "internet-facing" : "internal"
  associate_public_ip_address = local.sidecar.public_sidecar
}

output "sidecar_load_balancer_dns" {
  value = module.cyral_sidecar.sidecar_load_balancer_dns
}

output "external_tgs" {
  value = [for v in aws_lb_target_group.external-tg : v.arn]
}

output "external_load_balancer_dns" {
  value = aws_lb.this.dns_name
}

resource "aws_lb" "this" {
  name               = "external-lb-test"
  internal           = false
  load_balancer_type = "network"
  subnets            = local.sidecar.subnets
}

resource "aws_lb_target_group" "external-tg" {
  for_each = { for port in local.external_tg_ports : tostring(port) => port }
  name     = "external-tg-${each.value}"
  port     = each.value
  protocol = "TCP"
  vpc_id   = local.sidecar.vpc_id
  health_check {
    port     = 9000
    protocol = "HTTP"
    path     = "/health"
  }
  deregistration_delay = 0
}

resource "aws_lb_listener" "external-lb-ls" {
  for_each = { for port in local.external_tg_ports : tostring(port) => port }
  load_balancer_arn = aws_lb.this.arn
  port              = each.value

  protocol        = "TCP"

  default_action {
    type             = "forward"
    target_group_arn = aws_lb_target_group.external-tg[each.key].arn
  }
}

resource "aws_security_group" "external-sg" {
  name   = "external-sg"
  vpc_id = local.sidecar.vpc_id

  dynamic "ingress" {
    for_each = local.external_tg_ports
    content {
      description     = "DB"
      from_port       = ingress.value
      to_port         = ingress.value
      protocol        = "tcp"
      cidr_blocks     = ["0.0.0.0/0"]
    }
  }
}

```