### PR TITLE
ENG-13935: Add output variables for AWS resources ARNs

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,8 +116,8 @@ No modules.
 
 | Name | Type |
 |------|------|
-| [aws_autoscaling_group.cyral-sidecar-asg](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/autoscaling_group) | resource |
-| [aws_cloudwatch_log_group.cyral-sidecar-lg](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudwatch_log_group) | resource |
+| [aws_autoscaling_group.asg](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/autoscaling_group) | resource |
+| [aws_cloudwatch_log_group.lg](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudwatch_log_group) | resource |
 | [aws_iam_instance_profile.sidecar_profile](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_instance_profile) | resource |
 | [aws_iam_policy.init_script_policy](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_policy) | resource |
 | [aws_iam_policy.sidecar_custom_certificate_secrets_manager](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_policy) | resource |
@@ -130,10 +130,10 @@ No modules.
 | [aws_lambda_function.self_signed_certificate](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/lambda_function) | resource |
 | [aws_lambda_invocation.self_signed_ca_certificate](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/lambda_invocation) | resource |
 | [aws_lambda_invocation.self_signed_tls_certificate](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/lambda_invocation) | resource |
-| [aws_launch_template.cyral_sidecar_lt](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/launch_template) | resource |
-| [aws_lb.cyral-lb](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/lb) | resource |
-| [aws_lb_listener.cyral-sidecar-lb-ls](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/lb_listener) | resource |
-| [aws_lb_target_group.cyral-sidecar-tg](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/lb_target_group) | resource |
+| [aws_launch_template.lt](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/launch_template) | resource |
+| [aws_lb.lb](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/lb) | resource |
+| [aws_lb_listener.ls](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/lb_listener) | resource |
+| [aws_lb_target_group.tg](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/lb_target_group) | resource |
 | [aws_route53_record.cyral-sidecar-dns-record](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/route53_record) | resource |
 | [aws_secretsmanager_secret.custom_tls_certificate](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/secretsmanager_secret) | resource |
 | [aws_secretsmanager_secret.self_signed_ca](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/secretsmanager_secret) | resource |
@@ -167,7 +167,7 @@ No modules.
 | <a name="input_additional_security_groups"></a> [additional\_security\_groups](#input\_additional\_security\_groups) | List of the IDs of the additional security groups that will be attached to the sidecar instances. If providing<br>`additional_target_groups`, use this parameter to provide security groups with the inbound rules to allow<br>inbound traffic from the target groups to the instances. | `list(string)` | `[]` | no |
 | <a name="input_additional_target_groups"></a> [additional\_target\_groups](#input\_additional\_target\_groups) | List of the ARNs of the additional target groups that will be attached to the sidecar instances. Use it in<br>conjunction with `additional_security_groups` to provide the inbound rules for the ports associated with <br>them, otherwise the incoming traffic from the target groups will not be allowed to access the EC2 instances. | `list(string)` | `[]` | no |
 | <a name="input_ami_id"></a> [ami\_id](#input\_ami\_id) | Amazon Linux 2 AMI ID for sidecar EC2 instances. The default behavior is to use the latest version.<br>In order to define a new image, provide the desired image id. | `string` | `""` | no |
-| <a name="input_asg_count"></a> [asg\_count](#input\_asg\_count) | Set to 1 to enable the ASG, 0 to disable. Only for debugging. | `number` | `1` | no |
+| <a name="input_asg_count"></a> [asg\_count](#input\_asg\_count) | (Deprecated) Set to 1 to enable the ASG, 0 to disable. Only for debugging. | `number` | `1` | no |
 | <a name="input_asg_desired"></a> [asg\_desired](#input\_asg\_desired) | The desired number of hosts to create in the auto scaling group | `number` | `1` | no |
 | <a name="input_asg_max"></a> [asg\_max](#input\_asg\_max) | The maximum number of hosts to create in the auto scaling group | `number` | `3` | no |
 | <a name="input_asg_min"></a> [asg\_min](#input\_asg\_min) | The minimum number of hosts to create in the auto scaling group | `number` | `1` | no |
@@ -238,11 +238,18 @@ No modules.
 
 | Name | Description |
 |------|-------------|
-| <a name="output_aws_cloudwatch_log_group_name"></a> [aws\_cloudwatch\_log\_group\_name](#output\_aws\_cloudwatch\_log\_group\_name) | Name of the CloudWatch log group where sidecar logs are stored. |
+| <a name="output_autoscaling_group_arn"></a> [autoscaling\_group\_arn](#output\_autoscaling\_group\_arn) | Auto scaling group ARN |
+| <a name="output_aws_cloudwatch_log_group_name"></a> [aws\_cloudwatch\_log\_group\_name](#output\_aws\_cloudwatch\_log\_group\_name) | Name of the CloudWatch log group where sidecar logs are stored |
 | <a name="output_aws_iam_role_arn"></a> [aws\_iam\_role\_arn](#output\_aws\_iam\_role\_arn) | Sidecar IAM role ARN |
 | <a name="output_aws_security_group_id"></a> [aws\_security\_group\_id](#output\_aws\_security\_group\_id) | Sidecar security group id |
-| <a name="output_sidecar_custom_certificate_role_arn"></a> [sidecar\_custom\_certificate\_role\_arn](#output\_sidecar\_custom\_certificate\_role\_arn) | IAM role ARN to use in the Sidecar Custom Certificate modules. |
-| <a name="output_sidecar_custom_certificate_secret_arn"></a> [sidecar\_custom\_certificate\_secret\_arn](#output\_sidecar\_custom\_certificate\_secret\_arn) | Secret ARN to use in the Sidecar Custom Certificate modules. |
+| <a name="output_custom_tls_certificate_secret_arn"></a> [custom\_tls\_certificate\_secret\_arn](#output\_custom\_tls\_certificate\_secret\_arn) | Sidecar custom certificate secret ARN |
+| <a name="output_launch_template_arn"></a> [launch\_template\_arn](#output\_launch\_template\_arn) | Launch template ARN |
+| <a name="output_load_balancer_arn"></a> [load\_balancer\_arn](#output\_load\_balancer\_arn) | Load balancer ARN |
+| <a name="output_self_signed_ca_cert_secret_arn"></a> [self\_signed\_ca\_cert\_secret\_arn](#output\_self\_signed\_ca\_cert\_secret\_arn) | Sidecar self signed CA certificate secret ARN |
+| <a name="output_self_signed_tls_cert_secret_arn"></a> [self\_signed\_tls\_cert\_secret\_arn](#output\_self\_signed\_tls\_cert\_secret\_arn) | Sidecar self signed TLS certificate secret ARN |
+| <a name="output_sidecar_credentials_secret_arn"></a> [sidecar\_credentials\_secret\_arn](#output\_sidecar\_credentials\_secret\_arn) | Sidecar secret ARN |
+| <a name="output_sidecar_custom_certificate_role_arn"></a> [sidecar\_custom\_certificate\_role\_arn](#output\_sidecar\_custom\_certificate\_role\_arn) | IAM role ARN to use in the Sidecar Custom Certificate modules |
+| <a name="output_sidecar_custom_certificate_secret_arn"></a> [sidecar\_custom\_certificate\_secret\_arn](#output\_sidecar\_custom\_certificate\_secret\_arn) | Secret ARN to use in the Sidecar Custom Certificate modules |
 | <a name="output_sidecar_dns"></a> [sidecar\_dns](#output\_sidecar\_dns) | Sidecar DNS endpoint |
 | <a name="output_sidecar_load_balancer_dns"></a> [sidecar\_load\_balancer\_dns](#output\_sidecar\_load\_balancer\_dns) | Sidecar load balancer DNS endpoint |
 <!-- END_TF_DOCS -->

--- a/cloudwatch_resources.tf
+++ b/cloudwatch_resources.tf
@@ -1,4 +1,9 @@
-resource "aws_cloudwatch_log_group" "cyral-sidecar-lg" {
+# TODO: Remove `moved` in next major
+moved {
+  from = aws_cloudwatch_log_group.cyral-sidecar-lg
+  to   = aws_cloudwatch_log_group.lg
+}
+resource "aws_cloudwatch_log_group" "lg" {
   name              = local.cloudwatch_log_group_name
   retention_in_days = var.cloudwatch_logs_retention
 }

--- a/ec2_locals.tf
+++ b/ec2_locals.tf
@@ -31,7 +31,7 @@ locals {
     aws_account_id                        = local.aws_account_id
     log_integration                       = var.log_integration
     metrics_integration                   = var.metrics_integration
-    log_group_name                        = aws_cloudwatch_log_group.cyral-sidecar-lg.name
+    log_group_name                        = aws_cloudwatch_log_group.lg.name
     secrets_location                      = local.sidecar_secrets_secret_name
     idp_sso_login_url                     = var.idp_sso_login_url
     idp_certificate                       = var.idp_certificate

--- a/ec2_locals.tf
+++ b/ec2_locals.tf
@@ -11,7 +11,7 @@ locals {
     (length(aws_route53_record.cyral-sidecar-dns-record) == 0 && length(var.sidecar_dns_name) > 0) ? (
       var.sidecar_dns_name
       ) : (
-      length(aws_route53_record.cyral-sidecar-dns-record) == 1 ? aws_route53_record.cyral-sidecar-dns-record[0].fqdn : aws_lb.cyral-lb[0].dns_name
+      length(aws_route53_record.cyral-sidecar-dns-record) == 1 ? aws_route53_record.cyral-sidecar-dns-record[0].fqdn : aws_lb.lb[0].dns_name
     )
   ) : ""
   curl                      = var.tls_skip_verify ? "curl -k" : "curl"

--- a/ec2_resources.tf
+++ b/ec2_resources.tf
@@ -69,6 +69,8 @@ moved {
   to   = aws_autoscaling_group.asg
 }
 resource "aws_autoscaling_group" "asg" {
+  # TODO: Remove `count` in next major
+  count = 1
   name  = "${local.name_prefix}-asg"
   launch_template {
     id      = aws_launch_template.lt.id

--- a/iam_resources.tf
+++ b/iam_resources.tf
@@ -9,7 +9,7 @@ locals {
 # where the resources are actually deployed. This prevents issues with
 # deployment pipelines that runs on AWS and deploys to different accounts.
 data "aws_arn" "cw_lg" {
-  arn = aws_cloudwatch_log_group.cyral-sidecar-lg.arn
+  arn = aws_cloudwatch_log_group.lg.arn
 }
 
 data "aws_iam_policy_document" "init_script_policy" {
@@ -32,7 +32,7 @@ data "aws_iam_policy_document" "init_script_policy" {
       "logs:PutLogEvents"
     ]
     resources = [
-      "${aws_cloudwatch_log_group.cyral-sidecar-lg.arn}:*"
+      "${aws_cloudwatch_log_group.lg.arn}:*"
     ]
   }
 

--- a/output.tf
+++ b/output.tf
@@ -4,7 +4,7 @@ locals {
 }
 
 output "autoscaling_group_arn" {
-  value       = aws_autoscaling_group.asg.arn
+  value       = aws_autoscaling_group.asg[0].arn
   description = "Auto scaling group ARN"
 }
 

--- a/output.tf
+++ b/output.tf
@@ -3,45 +3,87 @@ locals {
   output_sidecar_custom_certificate_role_arn   = local.output_sidecar_custom_certificate_secret_arn
 }
 
-output "sidecar_dns" {
-  value       = local.sidecar_endpoint
-  description = "Sidecar DNS endpoint"
+output "autoscaling_group_arn" {
+  value       = aws_autoscaling_group.asg.arn
+  description = "Auto scaling group ARN"
 }
 
-output "sidecar_load_balancer_dns" {
-  value       = var.deploy_load_balancer ? aws_lb.cyral-lb[0].dns_name : null
-  description = "Sidecar load balancer DNS endpoint"
+# TODO: Rename to `cloudwatch_log_group_name` in next major version
+output "aws_cloudwatch_log_group_name" {
+  value       = aws_cloudwatch_log_group.lg.name
+  description = "Name of the CloudWatch log group where sidecar logs are stored"
 }
 
+# TODO: Rename to `iam_role_arn` in next major version
 output "aws_iam_role_arn" {
   value       = local.create_sidecar_role ? aws_iam_role.sidecar_role[0].arn : null
   description = "Sidecar IAM role ARN"
 }
 
+# TODO: Rename to `security_group_id` in next major version
 output "aws_security_group_id" {
   value       = aws_security_group.instance.id
   description = "Sidecar security group id"
 }
 
-output "sidecar_custom_certificate_secret_arn" {
-  value = local.output_sidecar_custom_certificate_secret_arn ? (
-    aws_secretsmanager_secret.custom_tls_certificate[0].id
-    ) : (
-    null
-  )
-  description = "Secret ARN to use in the Sidecar Custom Certificate modules."
+output "custom_tls_certificate_secret_arn" {
+  value       = local.create_custom_tls_certificate_secret ? aws_secretsmanager_secret.custom_tls_certificate[0].arn : null
+  description = "Sidecar custom certificate secret ARN"
 }
 
+output "launch_template_arn" {
+  value       = aws_launch_template.lt.arn
+  description = "Launch template ARN"
+}
+
+output "load_balancer_arn" {
+  value       = var.deploy_load_balancer ? aws_lb.lb[0].arn : null
+  description = "Load balancer ARN"
+}
+
+output "self_signed_ca_cert_secret_arn" {
+  value       = aws_secretsmanager_secret.self_signed_ca.arn
+  description = "Sidecar self signed CA certificate secret ARN"
+}
+
+output "self_signed_tls_cert_secret_arn" {
+  value       = aws_secretsmanager_secret.self_signed_tls_cert.arn
+  description = "Sidecar self signed TLS certificate secret ARN"
+}
+
+output "sidecar_credentials_secret_arn" {
+  value       = var.deploy_secrets ? aws_secretsmanager_secret.sidecar_secrets[0].arn : null
+  description = "Sidecar secret ARN"
+}
+
+# TODO: Rename to `custom_certificate_role_arn` in next major version
 output "sidecar_custom_certificate_role_arn" {
   value = local.output_sidecar_custom_certificate_role_arn ? (
     aws_iam_role.sidecar_custom_certificate[0].arn
     ) : (
     null
   )
-  description = "IAM role ARN to use in the Sidecar Custom Certificate modules."
+  description = "IAM role ARN to use in the Sidecar Custom Certificate modules"
 }
 
-output "aws_cloudwatch_log_group_name" {
-  value       = aws_cloudwatch_log_group.cyral-sidecar-lg.name
-  description = "Name of the CloudWatch log group where sidecar logs are stored."
+# TODO: Rename to `custom_certificate_secret_arn` in next major version
+output "sidecar_custom_certificate_secret_arn" {
+  value = local.output_sidecar_custom_certificate_secret_arn ? (
+    aws_secretsmanager_secret.custom_tls_certificate[0].id
+    ) : (
+    null
+  )
+  description = "Secret ARN to use in the Sidecar Custom Certificate modules"
+}
+
+# TODO: Rename to `dns` in next major version
+output "sidecar_dns" {
+  value       = local.sidecar_endpoint
+  description = "Sidecar DNS endpoint"
+}
+
+# TODO: Rename to `load_balancer_dns` in next major version
+output "sidecar_load_balancer_dns" {
+  value       = var.deploy_load_balancer ? aws_lb.lb[0].dns_name : null
+  description = "Sidecar load balancer DNS endpoint"
 }

--- a/route53_resources.tf
+++ b/route53_resources.tf
@@ -4,6 +4,6 @@ resource "aws_route53_record" "cyral-sidecar-dns-record" {
   name            = var.sidecar_dns_name
   type            = "CNAME"
   ttl             = "300"
-  records         = [aws_lb.cyral-lb[0].dns_name]
+  records         = [aws_lb.lb[0].dns_name]
   allow_overwrite = var.sidecar_dns_overwrite
 }

--- a/variables_aws.tf
+++ b/variables_aws.tf
@@ -8,7 +8,7 @@ EOF
 }
 
 variable "asg_count" {
-  description = "Set to 1 to enable the ASG, 0 to disable. Only for debugging."
+  description = "(Deprecated) Set to 1 to enable the ASG, 0 to disable. Only for debugging."
   type        = number
   default     = 1
 }


### PR DESCRIPTION
Add output variables for AWS resources ARNs to improve module's usability.

Tested with the following example:

```hcl
terraform {
  required_providers {
    cyral = {
      source  = "cyralinc/cyral"
      version = "~> 4.7"
    }
  }
}

locals {
  control_plane_host = ""

  pg = {
    address = ""
    port = 5432
  }

  sidecar = {
    # Set to true if you want a sidecar deployed with an
    # internet-facing load balancer (requires a public subnet).
    public_sidecar = true

    ports = [5432, 5433, 5434]
    # Set the ID of VPC that the sidecar will be deployed to
    vpc_id = ""
    # Set the IDs of the subnets that the sidecar will be deployed to
    subnets = [""]

    # Set the allowed CIDR block for SSH access to the sidecar
    ssh_inbound_cidr = ["0.0.0.0/0"]
    # Set the allowed CIDR block for database access through the
    # sidecar
    db_inbound_cidr = ["0.0.0.0/0"]
    # Set the allowed CIDR block for monitoring requests to the
    # sidecar
    monitoring_inbound_cidr = ["0.0.0.0/0"]
  }
}

provider "aws" {
  region = "us-east-1"
}

provider "cyral" {
  control_plane = local.control_plane_host
}

resource "cyral_repository" "pg" {
  name = "pgRepo"
  type = "postgresql"

  repo_node {
    host = local.pg.address
    port = local.pg.port
  }
}

resource "cyral_sidecar_listener" "pg" {
  for_each   = { for p in concat(local.sidecar.ports) : tostring(p) => p }
  sidecar_id = cyral_sidecar.sidecar.id
  repo_types = ["postgresql"]
  network_address {
    port = each.value
  }
}

resource "cyral_repository_binding" "pg" {
  for_each      = { for p in concat(local.sidecar.ports) : tostring(p) => p }
  sidecar_id    = cyral_sidecar.sidecar.id
  repository_id = cyral_repository.pg.id
  listener_binding {
    listener_id = cyral_sidecar_listener.pg[each.value].listener_id
  }
}

resource "cyral_sidecar" "sidecar" {
  name              = "my-sidecar"
  deployment_method = "terraform"
}

resource "cyral_sidecar_credentials" "sidecar_credentials" {
  sidecar_id = cyral_sidecar.sidecar.id
}

module "cyral_sidecar" {
  source = "github.com/cyralinc/terraform-aws-sidecar-ec2?ref=feat%2FENG-13935"

  sidecar_version = "v4.14.0"

  use_single_container = true

  sidecar_id    = cyral_sidecar.sidecar.id
  control_plane = local.control_plane_host
  client_id     = cyral_sidecar_credentials.sidecar_credentials.client_id
  client_secret = cyral_sidecar_credentials.sidecar_credentials.client_secret

  sidecar_ports = local.sidecar.ports

  vpc_id  = local.sidecar.vpc_id
  subnets = local.sidecar.subnets

  ssh_inbound_cidr        = local.sidecar.ssh_inbound_cidr
  db_inbound_cidr         = local.sidecar.db_inbound_cidr
  monitoring_inbound_cidr = local.sidecar.monitoring_inbound_cidr

  deploy_load_balancer          = true

  load_balancer_scheme        = local.sidecar.public_sidecar ? "internet-facing" : "internal"
  associate_public_ip_address = local.sidecar.public_sidecar
}

output "autoscaling_group_arn" {
  value = module.cyral_sidecar.autoscaling_group_arn
}

output "aws_cloudwatch_log_group_name" {
  value = module.cyral_sidecar.aws_cloudwatch_log_group_name
}

output "aws_iam_role_arn" {
  value = module.cyral_sidecar.aws_iam_role_arn
}

output "aws_security_group_id" {
  value = module.cyral_sidecar.aws_security_group_id
}

output "custom_tls_certificate_secret_arn" {
  value = module.cyral_sidecar.custom_tls_certificate_secret_arn
}

output "launch_template_arn" {
  value = module.cyral_sidecar.launch_template_arn
}

output "load_balancer_arn" {
  value = module.cyral_sidecar.load_balancer_arn
}

output "self_signed_ca_cert_secret_arn" {
  value = module.cyral_sidecar.self_signed_ca_cert_secret_arn
}

output "self_signed_tls_cert_secret_arn" {
  value = module.cyral_sidecar.self_signed_tls_cert_secret_arn
}

output "sidecar_credentials_secret_arn" {
  value = module.cyral_sidecar.sidecar_credentials_secret_arn
}

output "sidecar_custom_certificate_role_arn" {
  value = module.cyral_sidecar.sidecar_custom_certificate_role_arn
}

output "sidecar_custom_certificate_secret_arn" {
  value = module.cyral_sidecar.sidecar_custom_certificate_secret_arn
}

output "sidecar_dns" {
  value = module.cyral_sidecar.sidecar_dns
}

output "sidecar_load_balancer_dns" {
  value = module.cyral_sidecar.sidecar_load_balancer_dns
}
```