### PR TITLE
Avoid LB recreation in upgrades from v4.4 or previous

### DIFF
--- a/ec2_resources.tf
+++ b/ec2_resources.tf
@@ -178,6 +178,10 @@ moved {
   from = aws_lb.cyral-lb
   to   = aws_lb.lb
 }
+moved {
+  from = aws_lb.lb
+  to   = aws_lb.lb[0]
+}
 resource "aws_lb" "lb" {
   count = var.deploy_load_balancer ? 1 : 0
   # If the LB already exists, use the name `<name_prefix>-lb`, otherwise use


### PR DESCRIPTION
Avoid LB recreation when upgrading directly from `v4.4` to `v4.6+`.