### PR TITLE
Remove unused variables

### DIFF
--- a/README.md
+++ b/README.md
@@ -177,8 +177,6 @@ No modules.
 | <a name="input_cloudwatch_log_group_name"></a> [cloudwatch\_log\_group\_name](#input\_cloudwatch\_log\_group\_name) | (Optional) Cloudwatch log group name. | `string` | `""` | no |
 | <a name="input_cloudwatch_logs_retention"></a> [cloudwatch\_logs\_retention](#input\_cloudwatch\_logs\_retention) | Cloudwatch logs retention in days | `number` | `14` | no |
 | <a name="input_container_registry"></a> [container\_registry](#input\_container\_registry) | Address of the container registry where Cyral images are stored. | `string` | `"public.ecr.aws/cyral"` | no |
-| <a name="input_container_registry_key"></a> [container\_registry\_key](#input\_container\_registry\_key) | Corresponding key for the user name provided to authenticate to the container registry. | `string` | `""` | no |
-| <a name="input_container_registry_username"></a> [container\_registry\_username](#input\_container\_registry\_username) | Username to authenticate to the container registry. | `string` | `""` | no |
 | <a name="input_control_plane"></a> [control\_plane](#input\_control\_plane) | Address of the control plane - <tenant>.cyral.com | `string` | n/a | yes |
 | <a name="input_custom_host_role"></a> [custom\_host\_role](#input\_custom\_host\_role) | (Optional) Name of an AWS IAM Role to attach to the EC2 instance profile. | `string` | `""` | no |
 | <a name="input_custom_tags"></a> [custom\_tags](#input\_custom\_tags) | Custom tags to be added to all AWS resources created | `map(any)` | `{}` | no |

--- a/docs/byos.md
+++ b/docs/byos.md
@@ -13,7 +13,6 @@ with the following format:
 {
     "clientId":"",
     "clientSecret":"",
-    "containerRegistryKey":"",
     "idpCertificate":"",
     "sidecarPrivateIdpKey":"",
     "sidecarPublicIdpCertificate":""
@@ -24,7 +23,6 @@ with the following format:
 | :---------------------------- | :------: | ------ |
 | `clientId`                    | Yes      | String |
 | `clientSecret`                | Yes      | String |
-| `containerRegistryKey`        | No       | String - Base64 encoded |
 | `idpCertificate`              | No       | String - new lines escaped (`replace(var.yourCertificate, "\n", "\\n")`) |
 | `sidecarPrivateIdpKey`        | No       | String - new lines escaped (`replace(var.yourCertificate, "\n", "\\n")`) |
 | `sidecarPublicIdpCertificate` | No       | String - new lines escaped (`replace(var.yourCertificate, "\n", "\\n")`) |

--- a/ec2_locals.tf
+++ b/ec2_locals.tf
@@ -30,7 +30,6 @@ locals {
     ca_certificate_secret_arn         = local.ca_certificate_secret_arn
     controlplane_host                 = var.control_plane
     container_registry                = var.container_registry
-    container_registry_username       = var.container_registry_username
     cloudwatch_log_group_name         = local.cloudwatch_log_group_name
     curl                              = local.curl
     idp_sso_login_url                 = var.idp_sso_login_url

--- a/files/cloud-init-functions.sh.tmpl
+++ b/files/cloud-init-functions.sh.tmpl
@@ -151,7 +151,6 @@ function get_sidecar_version () {
 
 function registry_login () {
     echo "Container Registry Login..."
-    local key=$(echo "$secret" | jq -r 'select(.containerRegistryKey != null) | .containerRegistryKey' | base64 --decode)
     if [[ ${container_registry} == *"aws"* ]]; then
         echo "(login): Logging in to AWS ECR..."
         eval $(aws ecr --no-include-email get-login  --region ${aws_region})

--- a/secretsmanager_resources.tf
+++ b/secretsmanager_resources.tf
@@ -2,7 +2,6 @@ locals {
   sidecar_secret = {
     clientId                    = var.client_id
     clientSecret                = var.client_secret
-    containerRegistryKey        = var.container_registry_key
     sidecarPublicIdpCertificate = replace(var.sidecar_public_idp_certificate, "\n", "\\n")
     sidecarPrivateIdpKey        = replace(var.sidecar_private_idp_key, "\n", "\\n")
     idpCertificate              = replace(var.idp_certificate, "\n", "\\n")

--- a/variables_sidecar.tf
+++ b/variables_sidecar.tf
@@ -4,19 +4,6 @@ variable "container_registry" {
   default     = "public.ecr.aws/cyral"
 }
 
-variable "container_registry_username" {
-  description = "Username to authenticate to the container registry."
-  type        = string
-  default     = ""
-}
-
-variable "container_registry_key" {
-  description = "Corresponding key for the user name provided to authenticate to the container registry."
-  type        = string
-  default     = ""
-  sensitive   = true
-}
-
 variable "client_id" {
   description = "(Optional) The client id assigned to the sidecar. If not provided, must provide a secret containing the respective client id using `secret_arn`."
   type        = string


### PR DESCRIPTION
Remove unused variables `container_registry_key` and `container_registry_username` that were missed in the first version of the new major.

These removals can be safely released as a patch as there is no use for these variables in the original code in `v5.0.0`.