### PR TITLE
Use lastest version of Amazon Linux 2023

### DIFF
--- a/README.md
+++ b/README.md
@@ -147,7 +147,7 @@ No modules.
 | [tls_private_key.tls](https://registry.terraform.io/providers/hashicorp/tls/latest/docs/resources/private_key) | resource |
 | [tls_self_signed_cert.ca](https://registry.terraform.io/providers/hashicorp/tls/latest/docs/resources/self_signed_cert) | resource |
 | [tls_self_signed_cert.tls](https://registry.terraform.io/providers/hashicorp/tls/latest/docs/resources/self_signed_cert) | resource |
-| [aws_ami.amazon_linux_2](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/ami) | data source |
+| [aws_ami.amazon_linux](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/ami) | data source |
 | [aws_arn.cw_lg](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/arn) | data source |
 | [aws_availability_zones.all](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/availability_zones) | data source |
 | [aws_caller_identity.current](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/caller_identity) | data source |

--- a/ec2_locals.tf
+++ b/ec2_locals.tf
@@ -4,7 +4,7 @@ data "aws_region" "current" {}
 data "aws_caller_identity" "current" {}
 
 locals {
-  ami_id = length(var.ami_id) > 0 ? var.ami_id : data.aws_ami.amazon_linux_2.id
+  ami_id = length(var.ami_id) > 0 ? var.ami_id : data.aws_ami.amazon_linux.id
 
   aws_account_id = data.aws_caller_identity.current.account_id
   aws_partition  = data.aws_partition.current.partition

--- a/ec2_resources.tf
+++ b/ec2_resources.tf
@@ -1,10 +1,10 @@
 data "aws_availability_zones" "all" {}
 
-data "aws_ami" "amazon_linux_2" {
+data "aws_ami" "amazon_linux" {
   most_recent = true
   filter {
     name   = "name"
-    values = ["amzn2-ami-hvm-2.0.*-x86_64-gp2"]
+    values = ["al2023-ami-2023.*kernel-6.*-x86_64"]
   }
   owners = ["amazon"]
 }


### PR DESCRIPTION
Update the module to use the latest version of Amazon Linux 2023. This will be released as a `patch` as this was already part of the plan for the major `v5` and has been extensively tested (including performance tests).